### PR TITLE
prevent sending nulls as counters

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -54,7 +54,7 @@ defmodule ExqUi.RouterPlug do
       end
       qtotal = "#{Enum.sum(queue_sizes)}"
 
-      {:ok, json} = Poison.encode(%{stat: %{id: "all", processed: processed, failed: failed, busy: busy, scheduled: scheduled, retrying: retrying, enqueued: qtotal}})
+      {:ok, json} = Poison.encode(%{stat: %{id: "all", processed: processed || 0, failed: failed || 0, busy: busy || 0, scheduled: scheduled || 0, retrying: retrying || 0, enqueued: qtotal}})
       conn |> send_resp(200, json) |> halt
     end
 


### PR DESCRIPTION
In some cases exq api returning nils instead of counters (`failed` column). 
visually it looks like this:
<img width="766" alt="screen shot 2016-03-21 at 13 11 37" src="https://cloud.githubusercontent.com/assets/736279/13915848/1902e79a-ef68-11e5-9c84-9323b3c98682.png">

This pull request preventing sending nulls and therefore no more missing counters on dashboard: 
<img width="590" alt="screen shot 2016-03-21 at 13 22 02" src="https://cloud.githubusercontent.com/assets/736279/13915866/32efa2b0-ef68-11e5-92e5-bd049c64d7bf.png">
