### PR TITLE
Fix "Scheduled" tab

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -186,7 +186,7 @@ defmodule ExqUi.RouterPlug do
       {:ok, date} = score
       |> String.to_float
       |> Timex.Date.from(:secs)
-      |> Timex.DateFormat.format("{ISO}")
+      |> Timex.format("{ISO}")
 
       date
     end


### PR DESCRIPTION
API endpoint  for Scheduled jobs tab is using outdated Timex format and therefore failing to execute.
(exq requries at least timex >= 2.0.0 )
This pull request changes formatter to actual one: https://github.com/bitwalker/timex#quickfast-introduction