### PR TITLE
Adds server configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ There are also a few configuration options for the UI:
 ```elixir
 config :exq_ui,
   webport: 4040,
-  web_namespace: ""
+  web_namespace: "",
+  server: true
 ```
 
 The webport configures which port to start the UI on, and the web_namespace configures what to use as the application root
@@ -59,6 +60,8 @@ The webport configures which port to start the UI on, and the web_namespace conf
 By default the empty namespace is used, so you can access the UI via:  `http://localhost:4040/`.
 
 When setting a different web_namespace, for example `exq_ui`, you can access the UI via: `http://localhost:4040/exq_ui`.
+
+The `server` option allows you to refrain from starting the web server during tests. It is set to `true` by default.
 
 ## Web UI:
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,7 @@ config :exq,
 
 config :exq_ui,
   web_port: 4040,
-  web_namespace: ""
+  web_namespace: "",
+  server: true
 
 import_config "#{Mix.env}.exs"

--- a/lib/exq_ui.ex
+++ b/lib/exq_ui.ex
@@ -9,6 +9,7 @@ defmodule ExqUi do
   def launch_app do
     web_port = Application.get_env(:exq_ui, :web_port, 4040)
     web_namespace = Application.get_env(:exq_ui, :web_namespace, "")
+    run_server? = Application.get_env(:exq_ui, :server, true)
 
     api_name = Exq.Api.Server.server_name(nil)
 
@@ -17,9 +18,14 @@ defmodule ExqUi do
     end
 
     {:ok, _} = Exq.Api.queue_size(api_name)
-    IO.puts "Starting ExqUI on Port #{web_port}"
 
-    Plug.Adapters.Cowboy.http ExqUi.RouterPlug,
-      [namespace: web_namespace, exq_opts: [name: api_name]], port: web_port
+    if run_server? do
+      IO.puts "Starting ExqUI on Port #{web_port}"
+      Plug.Adapters.Cowboy.http ExqUi.RouterPlug,
+        [namespace: web_namespace, exq_opts: [name: api_name]], port: web_port
+    else
+      import Supervisor.Spec, warn: false
+      Supervisor.start_link([], strategy: :one_for_one)
+    end
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -4,11 +4,12 @@ defmodule ExqUi.RouterPlug do
   alias ExqUi.RouterPlug.Router
 
   def init(options) do
-    if options[:exq_opts] do
-      enq_opts = options[:exq_opts]
-    else
-      enq_opts = [name: Exq.Api.Server.server_name(nil)]
-    end
+    enq_opts =
+      if options[:exq_opts] do
+        options[:exq_opts]
+      else
+        [name: Exq.Api.Server.server_name(nil)]
+      end
     Keyword.put(options, :exq_opts, enq_opts)
   end
 
@@ -102,7 +103,7 @@ defmodule ExqUi.RouterPlug do
       conn |> send_resp(204, "") |> halt
     end
 
-    post "/api/failures/:id/retry" do
+    post "/api/failures/:_id/retry" do
       # TODO
       conn |> send_resp(200, "") |> halt
     end


### PR DESCRIPTION
If set to false, an empty supervisor will be started instead of the web server. This was a workaround to still return `{:ok, pid}` in  `Application.start/2` (I'm interested to see if you have any better suggestions here).

I also fixed up a couple simple compiler warnings in `web/router.ex`, but I can back those out if you'd like.

Fixes issue #21 