### PR TITLE
Fixed typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ config :exq,
 There are also a few configuration options for the UI:
 ```elixir
 config :exq_ui,
-  webport: 4040,
+  web_port: 4040,
   web_namespace: "",
   server: true
 ```


### PR DESCRIPTION
config option "web_port" was misspelled as "webport"