### PR TITLE
Fix Elixir compile warnings

### DIFF
--- a/lib/exq_ui.ex
+++ b/lib/exq_ui.ex
@@ -3,7 +3,7 @@ defmodule ExqUi do
   import Supervisor.Spec, warn: false
 
   def start(_type, _args) do
-    launch_app
+    launch_app()
   end
 
   def launch_app do

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule ExqUi.Mixfile do
       Exq UI is the UI component for Exq, a job processing library.  Exq UI provides the UI dashboard
       to display stats on job processing.
       """,
-      deps: deps,
+      deps: deps(),
       test_coverage: [tool: ExCoveralls]
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -35,9 +35,9 @@ defmodule ExqTestUtil do
 
   def assert_exq_up(exq) do
     my_pid = String.to_atom(UUID.uuid4)
-    Process.register(self, my_pid)
+    Process.register(self(), my_pid)
     {:ok, _} = Exq.enqueue(exq, "default", "ExqTestUtil.SendWorker", [my_pid])
-    wait_long
+    wait_long()
     ExUnit.Assertions.assert_received {:worked}
     Process.unregister(my_pid)
   end
@@ -83,9 +83,9 @@ defmodule TestRedis do
   end
 
   def setup do
-    {:ok, redis} = Redix.start_link([host: redis_host, port: redis_port])
+    {:ok, redis} = Redix.start_link([host: redis_host(), port: redis_port()])
     Process.register(redis, :testredis)
-    flush_all
+    flush_all()
     :ok
   end
 
@@ -96,7 +96,7 @@ defmodule TestRedis do
   def teardown do
     if !Process.whereis(:testredis) do
       # For some reason at the end of test the link is down, before we acutally stop and unregister?
-      {:ok, redis} = Redix.start_link([host: redis_host, port: redis_port])
+      {:ok, redis} = Redix.start_link([host: redis_host(), port: redis_port()])
       Process.register(redis, :testredis)
     end
     Process.unregister(:testredis)

--- a/test/ui_test.exs
+++ b/test/ui_test.exs
@@ -10,7 +10,7 @@ defmodule Exq.ApiTest do
 
   setup_all do
     TestRedis.setup
-    {:ok, sup} = Exq.start_link([host: redis_host, port: redis_port, name: Exq, mode: :api])
+    {:ok, sup} = Exq.start_link([host: redis_host(), port: redis_port(), name: Exq, mode: :api])
     on_exit fn ->
       TestRedis.teardown
       stop_process(sup)
@@ -49,7 +49,7 @@ defmodule Exq.ApiTest do
   end
 
   test "serves the processes" do
-    JobStat.add_process(:testredis, "exq", %Process{pid: self, job: %Job{jid: "1234"}, started_at: 1470539976.93175})
+    JobStat.add_process(:testredis, "exq", %Process{pid: self(), job: %Job{jid: "1234"}, started_at: 1470539976.93175})
     conn = conn(:get, "/api/processes") |> call
     assert conn.status == 200
     {:ok, json} = Config.serializer.decode(conn.resp_body)

--- a/web/router.ex
+++ b/web/router.ex
@@ -188,9 +188,9 @@ defmodule ExqUi.RouterPlug do
     EEx.function_from_file :defp, :render_index, index_path, [:assigns]
 
     match _ do
-      base = ""
-      if conn.assigns[:namespace] != "" do
-        base = "#{conn.assigns[:namespace]}/"
+      base = case conn.assigns[:namespace] do
+        "" -> ""
+        namespace -> "#{namespace}/"
       end
 
       conn


### PR DESCRIPTION
This fixes the following warnings:

```
> mix clean && mix compile
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:20

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:20

Compiling 5 files (.ex)
warning: variable "launch_app" does not exist and is being expanded to "launch_app()", please use parentheses to remove the ambiguity or change the variable name
  lib/exq_ui.ex:6

warning: the variable "base" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  web/router.ex:198

Generated exq_ui app
```

And in the tests:

```
> mix clean && mix test --no-start
Compiling 5 files (.ex)
Generated exq_ui app
warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:38

warning: variable "wait_long" does not exist and is being expanded to "wait_long()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:40

warning: variable "redis_host" does not exist and is being expanded to "redis_host()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:86

warning: variable "redis_port" does not exist and is being expanded to "redis_port()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:86

warning: variable "flush_all" does not exist and is being expanded to "flush_all()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:88

warning: variable "redis_host" does not exist and is being expanded to "redis_host()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:99

warning: variable "redis_port" does not exist and is being expanded to "redis_port()", please use parentheses to remove the ambiguity or change the variable name
  test/test_helper.exs:99

Excluding tags: [failure_scenarios: true]

warning: variable "redis_host" does not exist and is being expanded to "redis_host()", please use parentheses to remove the ambiguity or change the variable name
  test/ui_test.exs:13

warning: variable "redis_port" does not exist and is being expanded to "redis_port()", please use parentheses to remove the ambiguity or change the variable name
  test/ui_test.exs:13

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  test/ui_test.exs:52

...
```