### PR TITLE
Increase error message display height

### DIFF
--- a/priv/ember/app/styles/exq.scss
+++ b/priv/ember/app/styles/exq.scss
@@ -10,7 +10,7 @@
 }
 
 .failure-error-message {
-  max-height: $line-height-computed;
+  max-height: ($line-height-computed * 10);
   overflow: auto;
   // white-space: pre;
 }


### PR DESCRIPTION
Prior to this commit, long error messages would only
display on a window of one line, forcing the user to scroll
through, viewing only a line at a time. This commit increases
the height of the box to a max of 10 lines, so that more
of the message can be viewed at once.