### PR TITLE
Update router to allow for namespaces that contain '/'s

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -25,7 +25,10 @@ defmodule ExqUi.RouterPlug do
     end
   end
 
-  def namespace(%Plug.Conn{path_info: [ns | path]} = conn, opts, ns) do
+  def namespace(%Plug.Conn{path_info: path_info} = conn, opts, ns) when is_list(path_info) and path_info != [] do
+    np_path = String.split(ns, "/")
+    path = Enum.slice(path_info, length(np_path)..length(path_info))
+
     Router.call(%Plug.Conn{conn | path_info: path}, Router.init(opts))
   end
 


### PR DESCRIPTION
We created a namespace with a '/' ex: 'foo/bar' and the exq_ui would not load. After looking into the issue the following was able to get us up and running.

I looked into adding tests, and got very lost. I would be willing to write some if you could provide guidance. 