### PR TITLE
Allow for Cowboy 2.5 to be valid

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,10 +34,10 @@ defmodule ExqUi.Mixfile do
   # { :foobar, "0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
     [
-      { :exq, "~> 0.9"},
-      { :plug, "~> 1.6.3"},
-      { :cowboy, "~>2.4.0 or ~> 1.0" },
-      { :excoveralls, "~> 0.3", only: :test },
+      {:exq, "~> 0.9"},
+      {:plug, "~> 1.6.3"},
+      {:cowboy, "~>2.4 or ~> 1.0" },
+      {:excoveralls, "~> 0.3", only: :test },
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ExqUi.Mixfile do
   defp deps do
     [
       {:exq, "~> 0.9"},
-      {:plug, "~> 1.6.3"},
+      {:plug, "~> 1.6"},
       {:cowboy, "~>2.4 or ~> 1.0" },
       {:excoveralls, "~> 0.3", only: :test },
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
While trying to upgrade to Phoenix 1.4 we're running into issues since exq_ui is pinned to Cowboy `2.4.x` and the newest `plug_cowboy` required for the upgrade requires `2.5`. Seems like everything works on our end after the change. 