### PR TITLE
Optionally display detailed args instead of [Object, Object]

### DIFF
--- a/priv/ember/app/controllers/failures/index.js
+++ b/priv/ember/app/controllers/failures/index.js
@@ -22,6 +22,9 @@ var IndexController = Ember.Controller.extend({
       return failure.save().then(function(_f) {
         return self.send('reloadStats');
       });
+    },
+    toggleArgsDetails: function() {
+      this.toggleProperty("argsDetails", true)
     }
   }
 });

--- a/priv/ember/app/controllers/retries/index.js
+++ b/priv/ember/app/controllers/retries/index.js
@@ -30,6 +30,9 @@ IndexController = Ember.Controller.extend({
         self.send('reloadStats');
         return self.store.unloadRecord(retry);
       });
+    },
+    toggleArgsDetails: function() {
+      this.toggleProperty("argsDetails", true)
     }
   }
 });

--- a/priv/ember/app/controllers/scheduled/index.js
+++ b/priv/ember/app/controllers/scheduled/index.js
@@ -22,6 +22,9 @@ IndexController = Ember.Controller.extend({
       return scheduled.save().then(function(_f) {
         return self.send('reloadStats');
       });
+    },
+    toggleArgsDetails: function() {
+      this.toggleProperty("argsDetails", true)
     }
   }
 });

--- a/priv/ember/app/models/job.js
+++ b/priv/ember/app/models/job.js
@@ -1,11 +1,15 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 var Job = DS.Model.extend({
   queue: DS.attr('string'),
   "class": DS.attr('string'),
-  args: DS.attr('string'),
+  args: DS.attr(),
   enqueued_at: DS.attr('date'),
-  started_at: DS.attr('date')
+  started_at: DS.attr('date'),
+  parsed_args: Ember.computed('args', function() {
+    return JSON.stringify(this.get('args'));
+  })
 });
 
 export default Job;

--- a/priv/ember/app/models/retry.js
+++ b/priv/ember/app/models/retry.js
@@ -1,13 +1,17 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 var Retry = DS.Model.extend({
   queue: DS.attr('string'),
   "class": DS.attr('string'),
-  args: DS.attr('string'),
+  args: DS.attr(),
   failed_at: DS.attr('date'),
   error_message: DS.attr('string'),
   retry: DS.attr('boolean'),
-  retry_count: DS.attr('number')
+  retry_count: DS.attr('number'),
+  parsed_args: Ember.computed('args', function() {
+    return JSON.stringify(this.get('args'));
+  })
 });
 
 export default Retry;

--- a/priv/ember/app/templates/failures/index.hbs
+++ b/priv/ember/app/templates/failures/index.hbs
@@ -4,7 +4,7 @@
     <tr>
       <th>Queue</th>
       <th>Class</th>
-      <th>Args</th>
+      <th {{action 'toggleArgsDetails'}}>Args {{#if argsDetails}}&#9664;{{else}}&#9654;{{/if}}</th>
       <th>Failed At</th>
       <th>Error</th>
       <th>Actions</th>
@@ -15,7 +15,13 @@
       <tr>
         <td>{{failure.queue}}</td>
         <td>{{failure.class}}</td>
-        <td>{{failure.args}}</td>
+        <td>
+          {{#if argsDetails}}
+            {{failure.parsed_args}}
+          {{else}}
+            {{failure.args}}
+          {{/if}}
+        </td>
         <td>{{failure.failed_at}}</td>
         <td>
           <div class="failure-error-message">{{failure.error_message}}</div>

--- a/priv/ember/app/templates/retries/index.hbs
+++ b/priv/ember/app/templates/retries/index.hbs
@@ -4,7 +4,7 @@
     <tr>
       <th>Queue</th>
       <th>Class</th>
-      <th>Args</th>
+      <th {{action 'toggleArgsDetails'}}>Args {{#if argsDetails}}&#9664;{{else}}&#9654;{{/if}}</th>
       <th>Failed At</th>
       <th>Retry</th>
       <th>Actions</th>
@@ -15,7 +15,13 @@
       <tr>
         <td>{{retry.queue}}</td>
         <td>{{retry.class}}</td>
-        <td>{{retry.args}}</td>
+        <td>
+          {{#if argsDetails}}
+            {{retry.parsed_args}}
+          {{else}}
+            {{retry.args}}
+          {{/if}}
+        </td>
         <td>{{retry.failed_at}}</td>
         <td>{{retry.retry_count}}</td>
         <td><button {{action 'removeRetry' retry on="click"}} class="btn btn-danger btn-xs">Delete</button><button {{action 'requeueRetry' retry on="click"}} class="btn btn-secondary btn-xs">Retry</button></td>

--- a/priv/ember/app/templates/scheduled/index.hbs
+++ b/priv/ember/app/templates/scheduled/index.hbs
@@ -4,7 +4,7 @@
     <tr>
       <th>Queue</th>
       <th>Class</th>
-      <th>Args</th>
+      <th {{action 'toggleArgsDetails'}}>Args {{#if argsDetails}}&#9664;{{else}}&#9654;{{/if}}</th>
       <th>Scheduled At</th>
       <th>Actions</th>
     </tr>
@@ -14,7 +14,13 @@
       <tr>
         <td>{{scheduled.queue}}</td>
         <td>{{scheduled.class}}</td>
-        <td>{{scheduled.args}}</td>
+        <td>
+          {{#if argsDetails}}
+            {{scheduled.parsed_args}}
+          {{else}}
+            {{scheduled.args}}
+          {{/if}}
+        </td>
         <td>{{scheduled.scheduled_at}}</td>
         <td><button {{action 'removeScheduled' scheduled on="click"}} class="btn btn-danger btn-xs">Delete</button></td>
       </tr>

--- a/priv/ember/dist/index.html
+++ b/priv/ember/dist/index.html
@@ -8,8 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     
-<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%220.0.0+a63c723b%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
-<script src="/ember-cli-live-reload.js" type="text/javascript"></script>
+<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%220.0.0+a9528651%22%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
 
     <base href="/<%= assigns[:base] %>" />
 
@@ -17,16 +16,16 @@
       window.exqNamespace = "<%= assigns[:base] %>";
     </script>
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/exqui.css">
+    <link rel="stylesheet" href="assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
+    <link rel="stylesheet" href="assets/exqui-7681777425da3a20659e38da02e58f61.css">
 
     
   </head>
   <body>
     
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/exqui.js"></script>
+    <script src="assets/vendor-787e285ac27dfa5eb790a9f69247f20d.js"></script>
+    <script src="assets/exqui-66333162f7f83dd75763966466ad1695.js"></script>
 
     
   </body>

--- a/priv/ember/dist/index.html
+++ b/priv/ember/dist/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     
-<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%220.0.0+a9528651%22%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
+<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%220.0.0+2d21030c%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
 
     <base href="/<%= assigns[:base] %>" />
 
@@ -16,16 +16,16 @@
       window.exqNamespace = "<%= assigns[:base] %>";
     </script>
 
-    <link rel="stylesheet" href="assets/vendor-d41d8cd98f00b204e9800998ecf8427e.css">
-    <link rel="stylesheet" href="assets/exqui-7681777425da3a20659e38da02e58f61.css">
+    <link rel="stylesheet" href="assets/vendor.css">
+    <link rel="stylesheet" href="assets/exqui.css">
 
     
   </head>
   <body>
     
 
-    <script src="assets/vendor-787e285ac27dfa5eb790a9f69247f20d.js"></script>
-    <script src="assets/exqui-66333162f7f83dd75763966466ad1695.js"></script>
+    <script src="assets/vendor.js"></script>
+    <script src="assets/exqui.js"></script>
 
     
   </body>

--- a/priv/ember/dist/index.html
+++ b/priv/ember/dist/index.html
@@ -8,7 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     
-<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%22v0.9.0%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
+<meta name="exqui/config/environment" content="%7B%22modulePrefix%22%3A%22exqui%22%2C%22environment%22%3A%22development%22%2C%22rootURL%22%3A%22/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22exqui%22%2C%22version%22%3A%220.0.0+a63c723b%22%7D%2C%22exportApplicationGlobal%22%3Atrue%7D" />
+<script src="/ember-cli-live-reload.js" type="text/javascript"></script>
 
     <base href="/<%= assigns[:base] %>" />
 

--- a/priv/ember/package.json
+++ b/priv/ember/package.json
@@ -19,7 +19,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
     "ember-browserify": "^1.1.13",
-    "ember-cli": "2.12.1",
+    "ember-cli": "^2.13.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-chart": "^3.1.0",


### PR DESCRIPTION
Brought up in #58 - it is a little annoying to not be able to see the full arguments.

[demo gif](https://share.getcloudapp.com/8LuZ9X09)

On a sidenote - I could not get this to run from my github repo in a mix project, only by setting the path to the `exq_ui` on my local machine. What did I do wrong?
