### PR TITLE
improve table layout

### DIFF
--- a/lib/exq_ui_web/live/components/table_component.html.heex
+++ b/lib/exq_ui_web/live/components/table_component.html.heex
@@ -27,8 +27,8 @@
           <%= for item <- @items do %>
               <tr>
                 <td class="text-center"><%= checkbox(f, item.id, hidden_input: false, checked_value: item.raw, class: "form-check-input js-select-row") %></td>
-                <%= for %{accessor: accessor} <- @columns do %>
-                    <td><%= accessor.(item) %></td>
+                <%= for %{accessor: accessor} = column <- @columns do %>
+                    <td class={column[:text_break] && "text-break"}><%= accessor.(item) %></td>
                 <% end %>
               </tr>
           <% end %>

--- a/lib/exq_ui_web/live/dead_live/index.ex
+++ b/lib/exq_ui_web/live/dead_live/index.ex
@@ -21,8 +21,8 @@ defmodule ExqUIWeb.DeadLive.Index do
         %{header: "Retry Count", accessor: fn item -> item.job.retry_count end},
         %{header: "Queue", accessor: fn item -> item.job.queue end},
         %{header: "Module", accessor: fn item -> item.job.class end},
-        %{header: "Arguments", accessor: fn item -> inspect(item.job.args) end},
-        %{header: "Error", accessor: fn item -> item.job.error_message end}
+        %{header: "Arguments", text_break: true, accessor: fn item -> inspect(item.job.args) end},
+        %{header: "Error", text_break: true, accessor: fn item -> item.job.error_message end}
       ])
       |> assign(:actions, [
         %{name: "delete", label: "Delete"},

--- a/lib/exq_ui_web/live/queue_live/show.ex
+++ b/lib/exq_ui_web/live/queue_live/show.ex
@@ -10,7 +10,7 @@ defmodule ExqUIWeb.QueueLive.Show do
     socket =
       assign(socket, :columns, [
         %{header: "Module", accessor: fn item -> item.job.class end},
-        %{header: "Arguments", accessor: fn item -> inspect(item.job.args) end}
+        %{header: "Arguments", text_break: true, accessor: fn item -> inspect(item.job.args) end}
       ])
       |> assign(:actions, [
         %{name: "delete", label: "Delete"},

--- a/lib/exq_ui_web/live/retry_live/index.ex
+++ b/lib/exq_ui_web/live/retry_live/index.ex
@@ -21,8 +21,8 @@ defmodule ExqUIWeb.RetryLive.Index do
         %{header: "Retry Count", accessor: fn item -> item.job.retry_count end},
         %{header: "Queue", accessor: fn item -> item.job.queue end},
         %{header: "Module", accessor: fn item -> item.job.class end},
-        %{header: "Arguments", accessor: fn item -> inspect(item.job.args) end},
-        %{header: "Error", accessor: fn item -> item.job.error_message end}
+        %{header: "Arguments", text_break: true, accessor: fn item -> inspect(item.job.args) end},
+        %{header: "Error", text_break: true, accessor: fn item -> item.job.error_message end}
       ])
       |> assign(:actions, [
         %{name: "delete", label: "Delete"},

--- a/lib/exq_ui_web/live/scheduled_live/index.ex
+++ b/lib/exq_ui_web/live/scheduled_live/index.ex
@@ -20,7 +20,7 @@ defmodule ExqUIWeb.ScheduledLive.Index do
         },
         %{header: "Queue", accessor: fn item -> item.job.queue end},
         %{header: "Module", accessor: fn item -> item.job.class end},
-        %{header: "Arguments", accessor: fn item -> inspect(item.job.args) end}
+        %{header: "Arguments", text_break: true, accessor: fn item -> inspect(item.job.args) end}
       ])
       |> assign(:actions, [
         %{name: "delete", label: "Delete"},

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule ExqUI.MixProject do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"},
+      {:redix, ">= 0.9.0"},
       {:floki, ">= 0.30.0", only: :test},
-
       # docs
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
Allow args and error column to break text at any point. Otherwise, the
table could overflow the container if the args or error cell has long
word